### PR TITLE
feature: Added filters and holidays to display in dashboard

### DIFF
--- a/Modules/ExchangeRates/app/Console/CheckExchangeRates.php
+++ b/Modules/ExchangeRates/app/Console/CheckExchangeRates.php
@@ -6,10 +6,7 @@ use App\Models\Currency;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Modules\ExchangeRates\Models\ExchangeRate;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use MaciejSz\Nbp\Service\CurrencyAverageRatesService;
-use Yasumi\Filters\BankHolidaysFilter;
 use Yasumi\Yasumi;
 
 class CheckExchangeRates extends Command

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Pages\Dashboard as BaseDashboard;
+use Filament\Pages\Dashboard\Concerns\HasFiltersAction;
+use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
+
+class Dashboard extends BaseDashboard
+{
+    use HasFiltersForm, HasFiltersAction;
+
+    public function filtersForm(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make()
+                    ->schema([
+                        DatePicker::make('startDate')
+                            ->default(now()->startOfMonth())
+                            ->label(__('dashboard.start_date'))
+                            ->displayFormat('d/m/Y')
+                            ->maxDate(now()->subDay())
+                            ->live()
+                            ->afterStateUpdated(function () {
+                                $this->dispatchFiltersUpdated();
+                            }),
+                        DatePicker::make('endDate')
+                            ->default(now())
+                            ->label(__('dashboard.end_date'))
+                            ->displayFormat('d/m/Y')
+                            ->maxDate(now())
+                            ->minDate(fn(Get $get) => $get('startDate'))
+                            ->live()
+                            ->afterStateUpdated(function () {
+                                $this->dispatchFiltersUpdated();
+                            }),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    /**
+     * Explicitly dispatch the filters updated event with current filters
+     */
+    protected function dispatchFiltersUpdated(): void
+    {
+        $this->dispatch('filament.pageFilterUpdated', data: $this->filters);
+    }
+
+//    protected function getHeaderActions(): array
+//    {
+//        return [
+//            FilterAction::make()
+//                ->form([
+//                    DatePicker::make('startDate')
+//                        ->default(function () {
+//                            return now()->startOfMonth()->format('Y-m-d');
+//                        })
+//                        ->label(__('dashboard.start_date'))
+//                        ->displayFormat('d/m/Y')
+//                        ->maxDate(now()->subDay())
+//                        ->afterStateUpdated(fn(Get $get) =>   $this->dispatch('filament.pageFilterUpdated', data: $get))
+//                        ->live(),
+//                    DatePicker::make('endDate')
+//                        ->default(function () {
+//                            return now()->format('Y-m-d');
+//                        })
+//                        ->label(__('dashboard.end_date'))
+//                        ->displayFormat('d/m/Y')
+//                        ->maxDate(now())
+//                        ->minDate(fn(Get $get) => $get('startDate'))
+//                        ->live()
+//                ])
+//                ->action(function (array $data): void {
+//                    $this->dispatch('filament.pageFilterUpdated', data: $data);
+//                })
+//        ];
+//    }
+}

--- a/app/Filament/Widgets/HolidayWidget.php
+++ b/app/Filament/Widgets/HolidayWidget.php
@@ -26,7 +26,9 @@ class HolidayWidget extends Widget
         'France',
         'Italy',
         'Netherlands',
-        'Sweden'
+        'Sweden',
+        'Spain',
+        'Switzerland'
     ];
 
     protected static bool $isLazy = false;

--- a/app/Filament/Widgets/HolidayWidget.php
+++ b/app/Filament/Widgets/HolidayWidget.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Carbon\Carbon;
+use Filament\Widgets\Concerns\InteractsWithPageFilters;
+use Filament\Widgets\Widget;
+use Log;
+use Yasumi\Yasumi;
+
+class HolidayWidget extends Widget
+{
+    use InteractsWithPageFilters;
+
+    protected static ?int $sort = 3;
+    protected static string $view = 'filament.widgets.holiday-widget';
+
+    public $year;
+    public $country;
+    public $holidays = [];
+    public $countries = [
+        'Poland',
+        'Germany',
+        'USA',
+        'UnitedKingdom',
+        'France',
+        'Italy',
+        'Netherlands',
+        'Sweden'
+    ];
+
+    protected static bool $isLazy = false;
+
+    protected $listeners = [
+        'refreshHolidays' => 'loadHolidays',
+        'filament.pageFilterUpdated' => 'handleFilterUpdated'
+    ];
+
+    public function mount()
+    {
+        // Safely access filters
+        $startDate = $this->filters['startDate'] ?? null;
+        $this->year = $startDate ? Carbon::parse($startDate)->format('Y') : now()->year;
+        $this->country = 'Poland';
+        $this->loadHolidays();
+    }
+
+    public function updatedCountry()
+    {
+        $this->loadHolidays();
+    }
+
+    public function handleFilterUpdated($data)
+    {
+        if (is_array($data) && isset($data['startDate'])) {
+            $this->year = $data['startDate'] ? Carbon::parse($data['startDate'])->format('Y') : now()->year;
+        }
+        $this->loadHolidays();
+    }
+
+    public function loadHolidays()
+    {
+        try {
+            $provider = Yasumi::create($this->country, (int)$this->year, app()->getLocale());
+            $allHolidays = $provider->getHolidays();
+            $this->holidays = [];
+            foreach ($allHolidays as $holiday) {
+                $holidayDate = Carbon::parse($holiday->format('Y-m-d'));
+                $this->holidays[] = [
+                    'name' => $holiday->getName(),
+                    'date' => $holiday->format('Y-m-d'),
+                    'day_of_week' => $holidayDate->translatedFormat('l'),
+                ];
+            }
+        } catch (\Throwable $e) {
+            Log::error('Holiday widget error: ' . $e->getMessage());
+            $this->holidays = [];
+        }
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -7,7 +7,6 @@ use App\Filament\Resources\BuyerResource;
 use App\Filament\Resources\CostCategoryResource;
 use App\Filament\Resources\CostResource;
 use App\Filament\Resources\InvoiceResource;
-use App\Models\CostCategory;
 use Coolsam\Modules\ModulesPlugin;
 use Filament\Navigation\NavigationBuilder;
 use Filament\Navigation\NavigationItem;
@@ -72,7 +71,7 @@ class AppPanelProvider extends PanelProvider
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([
-                Pages\Dashboard::class,
+                \App\Filament\Pages\Dashboard::class
             ])
             ->navigation(function (NavigationBuilder $builder): NavigationBuilder {
                 return $builder

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "azuyalabs/yasumi": "^2.7",
         "bezhansalleh/filament-language-switch": "^3.1",
         "coolsam/modules": "^4",
         "filament/actions": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f49eae2262ef7d4b987009120a016d55",
+    "content-hash": "46443b1684d1c36748a1a5cb573448a9",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -71,6 +71,79 @@
                 "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.2.29"
             },
             "time": "2025-02-25T05:18:46+00:00"
+        },
+        {
+            "name": "azuyalabs/yasumi",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/azuyalabs/yasumi.git",
+                "reference": "37d1215d4f4012d3185bb9990c76ca17a4ff1c30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/azuyalabs/yasumi/zipball/37d1215d4f4012d3185bb9990c76ca17a4ff1c30",
+                "reference": "37d1215d4f4012d3185bb9990c76ca17a4ff1c30",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "friendsofphp/php-cs-fixer": "^2.19 || ^3.40",
+                "mikey179/vfsstream": "^1.6",
+                "phan/phan": "^5.4",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.5 || ^9.6",
+                "vimeo/psalm": "^5.16"
+            },
+            "suggest": {
+                "ext-calendar": "For calculating the date of Easter"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yasumi\\": "src/Yasumi/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sacha Telgenhof",
+                    "email": "me@sachatelgenhof.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "The easy PHP Library for calculating holidays.",
+            "homepage": "https://www.yasumi.dev",
+            "keywords": [
+                "Bank",
+                "calculation",
+                "calendar",
+                "celebration",
+                "date",
+                "holiday",
+                "holidays",
+                "national",
+                "time"
+            ],
+            "support": {
+                "docs": "https://www.yasumi.dev",
+                "issues": "https://github.com/azuyalabs/yasumi/issues",
+                "source": "https://github.com/azuyalabs/yasumi"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/sachatelgenhof",
+                    "type": "other"
+                }
+            ],
+            "time": "2024-01-07T14:12:44+00:00"
         },
         {
             "name": "bezhansalleh/filament-language-switch",

--- a/database/migrations/2025_05_04_115016_create_telescope_entries_table.php
+++ b/database/migrations/2025_05_04_115016_create_telescope_entries_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return config('telescope.storage.database.connection');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('telescope_entries', function (Blueprint $table) {
+            $table->bigIncrements('sequence');
+            $table->uuid('uuid');
+            $table->uuid('batch_id');
+            $table->string('family_hash')->nullable();
+            $table->boolean('should_display_on_index')->default(true);
+            $table->string('type', 20);
+            $table->longText('content');
+            $table->dateTime('created_at')->nullable();
+
+            $table->unique('uuid');
+            $table->index('batch_id');
+            $table->index('family_hash');
+            $table->index('created_at');
+            $table->index(['type', 'should_display_on_index']);
+        });
+
+        $schema->create('telescope_entries_tags', function (Blueprint $table) {
+            $table->uuid('entry_uuid');
+            $table->string('tag');
+
+            $table->primary(['entry_uuid', 'tag']);
+            $table->index('tag');
+
+            $table->foreign('entry_uuid')
+                ->references('uuid')
+                ->on('telescope_entries')
+                ->onDelete('cascade');
+        });
+
+        $schema->create('telescope_monitoring', function (Blueprint $table) {
+            $table->string('tag')->primary();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('telescope_entries_tags');
+        $schema->dropIfExists('telescope_entries');
+        $schema->dropIfExists('telescope_monitoring');
+    }
+};

--- a/lang/en/dashboard.php
+++ b/lang/en/dashboard.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'data_filter'   => 'Data Filter',
+    'start_date'    => 'Start Date',
+    'end_date'      => 'End Date',
+    'holidays'      => 'Holidays',
+    'holidays_not_found' => 'No Holidays Found',
+    'holiday'       => 'Holiday',
+    'date'          => 'Date',
+    'day'           => 'Day',
+    'country'       => [
+        'Poland'        => 'Poland',
+        'USA'           => 'USA',
+        'UnitedKingdom' => 'UK',
+        'Germany'       => 'Germany',
+        'France'        => 'France',
+        'Italy'         => 'Italy',
+        'Spain'         => 'Spain',
+        'Netherlands'   => 'Netherlands',
+        'Switzerland'   => 'Switzerland',
+        'Sweden'        => 'Sweden',
+    ],
+
+];

--- a/lang/pl/dashboard.php
+++ b/lang/pl/dashboard.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'data_filter'   => 'Filtruj',
+    'start_date'    => 'Data początkowa',
+    'end_date'      => 'Data końcowa',
+    'holidays'      => 'Święta',
+    'holidays_not_found' => 'Nie znaleziono świąt',
+    'holiday'       => 'Święto',
+    'date'          => 'Data',
+    'day'           => 'Dzień tyg.',
+    'country'       => [
+        'Poland'        => 'Polska',
+        'USA'           => 'USA',
+        'UnitedKingdom' => 'Wielka Brytania',
+        'Germany'       => 'Niemcy',
+        'France'        => 'Francja',
+        'Italy'         => 'Włochy',
+        'Spain'         => 'Hiszpania',
+        'Netherlands'   => 'Holandia',
+        'Switzerland'   => 'Szwajcaria',
+        'Sweden'        => 'Szwecja',
+    ],
+
+];

--- a/resources/views/filament/widgets/holiday-widget.blade.php
+++ b/resources/views/filament/widgets/holiday-widget.blade.php
@@ -30,7 +30,7 @@
                 </tr>
             @empty
                 <tr>
-                    <td colspan="3" class="text-center py-4 text-gray-500">{{ __('dashboard.country.holidays_not_found') }}</td>
+                    <td colspan="3" class="text-center py-4 text-gray-500">{{ __('dashboard.holidays_not_found') }}</td>
                 </tr>
             @endforelse
             </tbody>

--- a/resources/views/filament/widgets/holiday-widget.blade.php
+++ b/resources/views/filament/widgets/holiday-widget.blade.php
@@ -1,0 +1,39 @@
+<x-filament::widget>
+    <x-filament::section header="holidays">
+        <x-slot name="heading">
+            {{ __('dashboard.holidays') }}
+        </x-slot>
+        <x-slot name="headerEnd">
+            <x-filament::input.wrapper class="p-0">
+                <x-filament::input.select wire:model.live="country">
+                    @foreach($countries as $country)
+                    <option value="{{$country}}">{{ __('dashboard.country.'.$country) }}</option>
+                    @endforeach
+                </x-filament::select>
+            </x-filament::input.wrapper>
+        </x-slot>
+
+        <table class="w-full text-sm">
+            <thead>
+            <tr>
+                <th class="text-left">{{ __('dashboard.holiday') }}</th>
+                <th class="text-left">{{ __('dashboard.date') }}</th>
+                <th class="text-left">{{ __('dashboard.day') }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            @forelse ($holidays as $holiday)
+                <tr>
+                    <td>{{ $holiday['name'] }}</td>
+                    <td>{{ $holiday['date'] }}</td>
+                    <td>{{ $holiday['day_of_week'] }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3" class="text-center py-4 text-gray-500">{{ __('dashboard.country.holidays_not_found') }}</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </x-filament::section>
+</x-filament::widget>

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,5 +4,4 @@ use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
 
-
 Schedule::command('telescope:prune --hours=48')->daily();


### PR DESCRIPTION
-The dashboard has an overview of holidays in the current year
-filter for future purpose, but can interact with holidays (display holidays per start year)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dashboard page with interactive date filters for start and end dates.
  - Added a holiday widget that displays holidays for a selected country and year, with dynamic country selection and localized display.
  - Added English and Polish translations for dashboard elements and country names.
  - Implemented a new Blade view for the holiday widget with country selection and holiday listing.

- **Improvements**
  - Enhanced workday calculation to account for public holidays as well as weekends.

- **Chores**
  - Added Yasumi library as a dependency for holiday calculations.
  - Added database tables to support Laravel Telescope data storage.

- **Style**
  - Minor formatting cleanup in console route file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->