### PR TITLE
fix: try fetch exchange rates from last 7 days 

### DIFF
--- a/Modules/ExchangeRates/app/Console/CheckExchangeRates.php
+++ b/Modules/ExchangeRates/app/Console/CheckExchangeRates.php
@@ -37,8 +37,10 @@ class CheckExchangeRates extends Command
             $startDate = Carbon::now()->subDays(7);
             $currencyAverages = CurrencyAverageRatesService::new();
             $currencies = Currency::select('code', 'id')
-                ->whereNot('code', '=','PLN')
-                ->whereIn('id', setting('general.currencies'))->get();
+-                ->whereNot('code', '=','PLN')
++                ->where('code', '!=', 'PLN')
+                ->whereIn('id', setting('general.currencies'))
+                ->get();
             $plnCurrency = Currency::whereCode('PLN')->firstOrFail();
             foreach ($currencies as $currency) {
                 $dateIterator = clone $startDate;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exchange rates are now fetched and updated for each of the last seven days, rather than just the previous workday.
- **Improvements**
  - Enhanced error handling provides clearer messages when fetching rates fails, including specific currency and date details.
  - Console output now indicates the date for each exchange rate retrieval attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->