### PR TITLE
fix: add parameters of seller to the invoice

### DIFF
--- a/resources/views/invoice/template/default/pdf.blade.php
+++ b/resources/views/invoice/template/default/pdf.blade.php
@@ -55,7 +55,14 @@ if($showDiscount)
         <div class="text-left font-semibold px-10">
             <p class="text-xs">
                 <strong>Sprzedawca (Seller):</strong><br>
-
+                {{setting('seller.company_name')}}<br>
+                {{setting('seller.address')}}<br>
+                {{setting('seller.postal_code')}}
+                {{setting('seller.city')}}<br>
+                {{setting('seller.country')}}<br>
+                @if(setting('seller.nip')!='')
+                    NIP/Tax ID: {{setting('seller.nip')}}<br>
+                @endif
             </p>
         </div>
         <div class="text-left font-semibold">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Seller details, including company name, address, postal code, city, country, and NIP/Tax ID (if available), are now displayed on invoice PDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->