### PR TITLE
fix issue with null buyer because of the contract type

### DIFF
--- a/app/Models/Buyer.php
+++ b/app/Models/Buyer.php
@@ -46,6 +46,7 @@ class Buyer extends Model
      */
     protected $casts = [
         'id' => 'integer',
+        'contract_type' => TypeOfContract::class,
     ];
 
     public function currency(): BelongsTo

--- a/app/Models/Buyer.php
+++ b/app/Models/Buyer.php
@@ -106,13 +106,15 @@ class Buyer extends Model
                 ->label(__('buyers.color'))
                 ->default(randomColorHex()),
             Select::make('contract_type')
+                ->required()
                 ->label(__('buyers.contract_type'))
                 ->options(TypeOfContract::class)
+                ->default(TypeOfContract::OTHER)
                 ->live(),
             TextInput::make('contract_rate')
                 ->label(__('buyers.contract_rate'))
                 ->numeric()
-                ->hidden(fn(Get $get) => $get('contract_type')===TypeOfContract::OTHER->value || $get('contract_type')==null)
+                ->hidden(fn(Get $get) => $get('contract_type')===TypeOfContract::OTHER || $get('contract_type')==null)
                 ->default(null),
             Select::make('currency_id')
                 ->label(__('invoices.currency'))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the form behavior for contract type selection by making the field required and setting a default value.
  - Updated the logic for displaying the contract rate field to ensure it is hidden when the contract type is set to "Other" or left blank.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->