### PR TITLE
add: seed without need to override old records

### DIFF
--- a/database/seeders/CurrencySeeder.php
+++ b/database/seeders/CurrencySeeder.php
@@ -611,7 +611,10 @@ class CurrencySeeder extends Seeder
         );
 
         foreach ($currencies as $currency) {
-            Currency::updateOrCreate($currency);
+            Currency::updateOrCreate(
+                ['code' => $currency['code']],
+                $currency
+            );
         }
     }
 }

--- a/database/seeders/CurrencySeeder.php
+++ b/database/seeders/CurrencySeeder.php
@@ -611,7 +611,7 @@ class CurrencySeeder extends Seeder
         );
 
         foreach ($currencies as $currency) {
-            Currency::create($currency);
+            Currency::updateOrCreate($currency);
         }
     }
 }

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Outerweb\Settings\Models\Setting;
 
 class SettingsSeeder extends Seeder
 {
@@ -13,19 +14,22 @@ class SettingsSeeder extends Seeder
      */
     public function run(): void
     {
-        DB::table('settings')->insert([
-            [
-                'key' => 'general.currencies',
-                'value' => json_encode(["35", "84", "109"]),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'key' => 'general.default_currency',
-                'value' => "84",
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]
-        ]);
+        $settings = Setting::first();
+        if(!$settings) {
+            DB::table('settings')->insert([
+                [
+                    'key' => 'general.currencies',
+                    'value' => json_encode(["35", "84", "109"]),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+                [
+                    'key' => 'general.default_currency',
+                    'value' => "84",
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]
+            ]);
+        }
     }
 }

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -14,8 +14,10 @@ class SettingsSeeder extends Seeder
      */
     public function run(): void
     {
-        $settings = Setting::first();
-        if(!$settings) {
+        if (! Setting::whereIn('key', [
+            'general.currencies',
+            'general.default_currency'
+        ])->exists()) {
             DB::table('settings')->insert([
                 [
                     'key' => 'general.currencies',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate currency and settings entries during database updates by ensuring existing records are updated or new entries are added only when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->