### PR TITLE
fix issue about cost amount min amount

### DIFF
--- a/app/Models/Cost.php
+++ b/app/Models/Cost.php
@@ -103,9 +103,9 @@ class Cost extends Model
                 ->required()
                 ->live()
                 ->numeric()
-                ->maxValue(0)
+                ->minValue(0)
                 ->afterStateUpdated(fn($state, callable $set, callable $get) =>
-                $set('amount_gross', is_numeric($get('amount')) ? $get('amount')*1.23 : 0)
+                $set('amount_gross', round(is_numeric($get('amount')) ? $get('amount') * 1.23 : 0, 2))
                 ),
             Select::make('currency_id')
                 ->label(__('invoices.currency'))
@@ -120,6 +120,7 @@ class Cost extends Model
             TextInput::make('amount_gross')
                 ->label(__('costs.amount_gross'))
                 ->required()
+                ->minValue(0)
                 ->live()
                 ->numeric(),
             TextInput::make('percent_deductible_from_taxes')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented negative values from being entered for amount and gross amount fields.
  - Ensured gross amount is rounded to two decimal places for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->